### PR TITLE
Modify eas build command for Android platform

### DIFF
--- a/.github/workflows/Quickapp.yml
+++ b/.github/workflows/Quickapp.yml
@@ -17,7 +17,7 @@ jobs:
       - run: npm ci
       - run: npm install -g eas-cli
       - run: mkdir -p apk-output
-      - run: eas build --platform android --profile production --wait --output-dir apk-output
+      - run: eas build --platform android
       - uses: actions/upload-artifact@v4
         with:
           name: apk


### PR DESCRIPTION
This pull request makes a minor update to the Android build step in the GitHub Actions workflow. The change simplifies the `eas build` command by removing the production profile, wait flag, and output directory specification.

- Simplified the Android build command in `.github/workflows/Quickapp.yml` by removing the `--profile production`, `--wait`, and `--output-dir apk-output` options from the `eas build` step.